### PR TITLE
Keep web socket static values on details page on uncheck of live monitor

### DIFF
--- a/src/components/pv/valuetable/ValueTable.js
+++ b/src/components/pv/valuetable/ValueTable.js
@@ -38,15 +38,7 @@ function ValueTable(props) {
             if (props.snapshot && !props.pvMonitoring) return;
             setPVValue(null);
             setPVSeverity(null);
-            setPVMin(null);
-            setPVMax(null);
-            setPVAlarmLow(null);
-            setPVAlarmHigh(null);
-            setPVWarnLow(null);
-            setPVWarnHigh(null);
-            setPVPrecision(null);
             setPVTimestamp(null);
-            setPVUnits(null);
         },
         shouldReconnect: (closeEvent) => true,
     });
@@ -81,15 +73,7 @@ function ValueTable(props) {
             if (props.snapshot && !props.pvMonitoring) return;
             setPVValue(null);
             setPVSeverity(null);
-            setPVMin(null);
-            setPVMax(null);
-            setPVAlarmLow(null);
-            setPVAlarmHigh(null);
-            setPVWarnLow(null);
-            setPVWarnHigh(null);
-            setPVPrecision(null);
             setPVTimestamp(null);
-            setPVUnits(null);
         }
     }, [props.pvMonitoring, props.snapshot, snapshot, props.isLoading, props.pvData, props.pvName, handleErrorMessage, handleOpenErrorAlert, sendJsonMessage, handleSeverity]);
 


### PR DESCRIPTION
don't clear the "static" information from PV web socket when the live monitoring is unchecked.

If ` REACT_APP_DEFAULT_LIVE_MONITORING` is false, then the static information will appear on page load and checking/unchecking the "Enable Live PV Monitoring" box will not clear the static values. Enabling the live monitoring will update any of these quote un quote static values if they have changed

If `REACT_APP_DEFAULT_LIVE_MONITORING` is true, then the static information will already be shown since the live monitor checkbox is on by default. and the values will remain if unchecked manually