### PR TITLE
show acknowledged message for alarm config logger

### DIFF
--- a/src/components/pv/alarmconfigtable/AlarmConfigTable.jsx
+++ b/src/components/pv/alarmconfigtable/AlarmConfigTable.jsx
@@ -100,6 +100,8 @@ function AlarmConfigTable(props) {
                                         let prettyConfigMsg = "";
                                         if (item.config_msg) {
                                             prettyConfigMsg = JSON.stringify(JSON.parse(item.config_msg), null, 2);
+                                        } else if (item.command) {
+                                            prettyConfigMsg = JSON.stringify(JSON.parse(item.command), null, 2);
                                         }
                                         const message_time = item.message_time ? new Date(item.message_time).toLocaleString("en-US", dateFormat) : "";
                                         return (


### PR DESCRIPTION
When an alarm is acknowledged or unacknowledged there is no config_message. I added an extra check for command when config_message is not given from the alarm logger.

`    {
        "message_time": "2025-03-15T01:01:25.716Z",
        "config": "command:/Accelerator/8.Controls/ALS:IOCS:DuplicateIocCount",
        "user": "tford",
        "host": "appsdev.als.lbl.gov",
        "command": "unacknowledge",
        "enabled": false
    },
`

`
    {
        "message_time": "2025-03-07T02:54:28.052Z",
        "config": "command:/Accelerator/8.Controls/ALS:IOCS:DuplicateIocCount",
        "user": "alsoper2",
        "host": "apps2.als.lbl.gov",
        "command": "acknowledge",
        "enabled": false
    },`