### PR TITLE
fix alarm config json parse error

### DIFF
--- a/src/components/pv/alarmconfigtable/AlarmConfigTable.jsx
+++ b/src/components/pv/alarmconfigtable/AlarmConfigTable.jsx
@@ -101,7 +101,7 @@ function AlarmConfigTable(props) {
                                         if (item.config_msg) {
                                             prettyConfigMsg = JSON.stringify(JSON.parse(item.config_msg), null, 2);
                                         } else if (item.command) {
-                                            prettyConfigMsg = JSON.stringify(JSON.parse(item.command), null, 2);
+                                            prettyConfigMsg = JSON.stringify(item.command, null, 2);
                                         }
                                         const message_time = item.message_time ? new Date(item.message_time).toLocaleString("en-US", dateFormat) : "";
                                         return (


### PR DESCRIPTION
pvinfo was breaking trying to JSON.parse the acknowledge/unacknowledge alarm config. The JSON.parse is not necessary because command is a string and not a full JSON parse-able object.

`{ "message_time": "2025-03-07T02:54:28.052Z", "config": "command:/Accelerator/8.Controls/ALS:IOCS:DuplicateIocCount", "user": "alsoper2", "host": "apps2.als.lbl.gov", "command": "acknowledge", "enabled": false },`

