### PR TITLE
Allow subscribing to PVs with inactive CF pvStatus

### DIFF
--- a/.env
+++ b/.env
@@ -64,7 +64,7 @@ REACT_APP_CF_URL=http://localhost:8080/ChannelFinder
 # Limit the number of CF results returned by a given query
 REACT_APP_CF_MAX_RESULTS=
 
-# Optional CF properties to include (https://github.com/ChannelFinder/recsync/blob/master/server/cf.conf#L46)
+# Optional CF properties to include (https://github.com/ChannelFinder/recsync/blob/master/server/demo.conf#L74)
 # recordType
 REACT_APP_CF_RECORD_TYPE=false
 # recordDesc
@@ -110,6 +110,11 @@ REACT_APP_LIVE_MONITOR_MAX=100
 # for small waveforms it can be nice to see. PVWS uses EPICS_CA_MAX_ARRAY_BYTES and that
 # can be used to limit giant waveforms coming across the websocket connection as a mitigation
 REACT_APP_PVWS_ALLOW_WAVEFORMS=false
+
+# By default, PV Info does not allow the user to subscribe to PVs with a status that is not "Active".
+# Switch this to true to allow PV Info to attempt to subscribe to these PVs. This could be useful
+# if your recceiver instance is not working but the PVs themselves are alive and accessible.
+REACT_APP_PVWS_IGNORE_CF_PVSTATUS=false
 
 ######################################################################################
 # Archiver Web Viewer

--- a/src/components/help/Help.jsx
+++ b/src/components/help/Help.jsx
@@ -85,9 +85,12 @@ function Help() {
                 </ul>
                 <li><strong>Status</strong></li>
                 <ul>
+
                   <li>
-                    Current status of this PV. Either Active or Inactive. Inactive means the PV is not up and indicates a problem with the IOC. If the PV is inactive then the PV value monitor
-                    checkbox will be disabled.
+                    Current status of this PV. Either Active or Inactive. Inactive means the PV is not synchronized with the recsync server and indicates a problem with the IOC or recsync.
+                    { import.meta.env.REACT_APP_PVWS_IGNORE_CF_PVSTATUS !== "true" &&
+                      <li>If the PV is inactive then the PV value monitor checkbox will be disabled.</li>
+                    }
                   </li>
                 </ul>
                 <li><strong>Record Type</strong></li>

--- a/src/components/home/queryresults/valuecheckbox/ValueCheckbox.jsx
+++ b/src/components/home/queryresults/valuecheckbox/ValueCheckbox.jsx
@@ -29,7 +29,10 @@ function ValueCheckbox(props) {
     }
 
     useEffect(() => {
-        if (props.pvStatus === "Inactive" || (import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true" && props.recordType === "waveform")) {
+        if (props.pvStatus !== "Active" && import.meta.env.REACT_APP_PVWS_IGNORE_CF_PVSTATUS !== "true") {
+            setEnabled(false);
+        }
+        else if (props.recordType === "waveform" && import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true") {
             setEnabled(false);
         }
     }, [props.pvStatus, props.recordType])
@@ -49,7 +52,7 @@ function ValueCheckbox(props) {
         <Tooltip arrow title={<div>Monitor<br />{props.pvName}</div>}>
             <Checkbox
                 checked={props.checked[props.id] && enabled}
-                disabled={props.pvStatus === "Inactive" || (import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true" && props.recordType === "waveform")}
+                disabled={!enabled}
                 color="primary"
                 onChange={handleMonitorPVChange(props.id)} >
             </Checkbox>

--- a/src/components/pv/PV.jsx
+++ b/src/components/pv/PV.jsx
@@ -176,11 +176,12 @@ function PV(props) {
                 </Box>
                 {
                     import.meta.env.REACT_APP_USE_PVWS === "true" ?
-                        import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS === "true" ?
-                        <FormControlLabel control={<Checkbox color="primary" checked={pvMonitoring} onChange={handlePVMonitoringChange}></Checkbox>} disabled={pvData?.pvStatus?.value === "Inactive"} label="Enable Live PV Monitoring" />
+                        <FormControlLabel
+                            control={<Checkbox color="primary" checked={pvMonitoring} onChange={handlePVMonitoringChange}></Checkbox>}
+                            disabled={!((import.meta.env.REACT_APP_PVWS_IGNORE_CF_PVSTATUS === "true" || pvData?.pvStatus?.value === "Active") && (import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS === "true" || pvData?.recordType?.value !== "waveform"))}
+                            label="Enable Live PV Monitoring" />
                         :
-                        <FormControlLabel control={<Checkbox color="primary" checked={pvMonitoring} onChange={handlePVMonitoringChange}></Checkbox>} disabled={pvData?.pvStatus?.value === "Inactive" || pvData?.recordType?.value === "waveform"} label="Enable Live PV Monitoring" />
-                        : null
+                        null
                 }
                 <Box sx={{ border: 1, borderColor: '#D1D5DB', borderRadius: 1, boxShadow: 2, mb: 2, overflow: "hidden" }}>
                     <Accordion expanded={detailsExpanded} onChange={handleDetailExpandedChange()}>

--- a/src/components/pv/valuetable/ValueTable.jsx
+++ b/src/components/pv/valuetable/ValueTable.jsx
@@ -56,21 +56,23 @@ function ValueTable(props) {
             if (props.pvData === null || Object.keys(props.pvData).length === 0 || props.isLoading) {
                 return;
             }
-            else if (props.pvData.pvStatus?.value === "Inactive") {
-                handleErrorMessage("Can't show live PV values - PV is in Inactive state");
-                handleSeverity("warning");
-                handleOpenErrorAlert(true);
-            }
-            else if (import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true" && props.pvData.recordType?.value === "waveform") {
+            const status = props.pvData.pvStatus?.value || "Unknown";
+
+            if (import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true" && props.pvData.recordType?.value === "waveform") {
                 handleErrorMessage("Can't show live PV values - Waveform record type not supported");
                 handleSeverity("warning");
                 handleOpenErrorAlert(true);
             }
-            else if (props.pvData.pvStatus?.value === "Active") {
+            else if (import.meta.env.REACT_APP_PVWS_IGNORE_CF_PVSTATUS === "true" || status === "Active") {
                 if (!subscribed) {
                     sendJsonMessage({ "type": "subscribe", "pvs": [props.pvName] });
                     setSubscribed(true);
                 }
+            }
+            else {
+                handleErrorMessage(`Can't show live PV values - PV is in ${status} state`);
+                handleSeverity("warning");
+                handleOpenErrorAlert(true);
             }
         }
         else {


### PR DESCRIPTION
Closes https://github.com/ChannelFinder/pvinfo/issues/99

This is mostly backwards compatible. Users have to add this new env var `REACT_APP_PVWS_IGNORE_CF_PVSTATUS` and set it to "true" to have an effect. There is one change. Before, the checks for disabling the checkbox specifically looked for `=== "Inactive"` where now it is instead `!== "Active"`.