### PR TITLE
Add option to show disconnected message for non-reachable PVs

### DIFF
--- a/.env
+++ b/.env
@@ -121,6 +121,11 @@ REACT_APP_PVWS_ALLOW_WAVEFORMS=false
 # if your recceiver instance is not working but the PVs themselves are alive and accessible.
 REACT_APP_PVWS_IGNORE_CF_PVSTATUS=false
 
+# By default, PV Info shows "Disconnected" for PVs that are not connected to their IOC
+# Switch this to false to revert to the old behavior where instead the box is left blank
+# Somewhat goes in tandem with IGNORE_CF_PVSTATUS variable
+REACT_APP_SHOW_DISCONNECTED=true
+
 ######################################################################################
 # Archiver Web Viewer
 ######################################################################################

--- a/src/components/home/queryresults/QueryResults.jsx
+++ b/src/components/home/queryresults/QueryResults.jsx
@@ -90,7 +90,11 @@ function QueryResults(props) {
             [firstRow, lastRow] = [parseInt(start) - 1, parseInt(end) - 1];
         }
         for (let i = firstRow; i <= lastRow; ++i) {
-            updateCurrentChecked(i, event.target.checked);
+            // only check mark active PVs, unless we are ignoring CF PV status
+            // matters now that we show "Disconnected" for PVs that are not connected to their IOC
+            if (import.meta.env.REACT_APP_PVWS_IGNORE_CF_PVSTATUS === "true" || pvs[i].pvStatus === "Active") {
+                updateCurrentChecked(i, event.target.checked);
+            }
         }
         return
     }, [updateCurrentChecked])

--- a/src/components/home/queryresults/valuecheckbox/ValueCheckbox.jsx
+++ b/src/components/home/queryresults/valuecheckbox/ValueCheckbox.jsx
@@ -35,7 +35,10 @@ function ValueCheckbox(props) {
         else if (props.recordType === "waveform" && import.meta.env.REACT_APP_PVWS_ALLOW_WAVEFORMS !== "true") {
             setEnabled(false);
         }
-    }, [props.pvStatus, props.recordType])
+        else {
+            setEnabled(true);
+        }
+    }, [props.pvStatus, props.recordType, props.pvName])
 
     // watch for changes in checked, if so send a subscribe message
     useEffect(() => {

--- a/src/components/pv/valuetable/ValueTable.jsx
+++ b/src/components/pv/valuetable/ValueTable.jsx
@@ -124,6 +124,8 @@ function ValueTable(props) {
             }
         }
         if (message.pv_value === null) {
+            setPVSeverity("DISCONNECTED");
+            setAlarmColor(colors.SEV_COLORS["UNDEFINED"]);
             return; // only if no text, b64dbl, b64int, ..., value property found
         }
         if (!props.snapshot) {


### PR DESCRIPTION
Closes https://github.com/ChannelFinder/pvinfo/issues/125

New option that is true by default to show `(DISCONNECTED)` on the home page for any PVs that pv web socket can't connect to. Toggle to false to instead not show anything if the PV doesn't have a value.

Now no matter what, on the PV details page the alarm severity will show `DISCONNECTED` in the `REACT_APP_UNDEFINED_SEVERITY_COLOR` if the web socket can't connect.

Also fixes 2 small bugs when `REACT_APP_PVWS_IGNORE_CF_PVSTATUS=false`
- Live monitor checkboxes would be disabled when switching search from active to inactive and then back to active
- The monitor all button was opening web socket subscriptions to PVs with pvStatus="Inactive"