### PR TITLE
change REACT_APP_USE_CAPUT_API_PROXY_CONNNECTOR to REACT_APP_USE_CAPUT_API_PROXY_CONNECTOR

### DIFF
--- a/.env
+++ b/.env
@@ -165,7 +165,7 @@ REACT_APP_AL_MAX_RESULTS=
 ######################################################################################
 
 REACT_APP_USE_CAPUTLOG=true
-REACT_APP_USE_CAPUT_API_PROXY_CONNNECTOR=true
+REACT_APP_USE_CAPUT_API_PROXY_CONNECTOR=true
 REACT_APP_ELASTICSEARCH_INDEX_NAME=
 REACT_APP_ELASTICSEARCH_API_KEY=
 REACT_APP_CAPUTLOG_URL=http://localhost:8084/caputlog-server

--- a/src/components/services/Services.jsx
+++ b/src/components/services/Services.jsx
@@ -164,7 +164,7 @@ function Services() {
                             config.USE_CAPUTLOG ? (
                                 <Service servName="Caput Log" connected={caputLogConnected}
                                     data={
-                                        config.USE_CAPUT_API_PROXY_CONNNECTOR
+                                        config.USE_CAPUT_API_PROXY_CONNECTOR
                                         ? {
                                             "Elastic Status": caputLogData?.elasticsearch?.connection,
                                             "Elastic Health": caputLogData?.elasticsearch?.health?.status,

--- a/src/config.js
+++ b/src/config.js
@@ -34,7 +34,12 @@ const getEnv = (prodKey, devKey) => {
 // caputlog elasticsearch connector - either direct or via a back-end proxy service
 const elasticIndexName = import.meta.env.REACT_APP_ELASTICSEARCH_INDEX_NAME;
 const elasticApikey = import.meta.env.REACT_APP_ELASTICSEARCH_API_KEY;
-const useProxy = parseBoolean(import.meta.env.REACT_APP_USE_CAPUT_API_PROXY_CONNNECTOR, true);
+// typo in config name was fixed but this is for backward compatibility
+const useProxy = parseBoolean(
+    import.meta.env.REACT_APP_USE_CAPUT_API_PROXY_CONNECTOR ??
+    import.meta.env.REACT_APP_USE_CAPUT_API_PROXY_CONNNECTOR,
+    true
+);
 
 const caputlogURL = getEnv("REACT_APP_CAPUTLOG_URL", "REACT_APP_CAPUTLOG_URL_DEV");
 
@@ -137,7 +142,7 @@ const config = {
 
     // CaputLog
     USE_CAPUTLOG: parseBoolean(import.meta.env.REACT_APP_USE_CAPUTLOG, false),
-    USE_CAPUT_API_PROXY_CONNNECTOR: useProxy,
+    USE_CAPUT_API_PROXY_CONNECTOR: useProxy,
 
     // Severity colors
     OK_SEVERITY_COLOR: import.meta.env.REACT_APP_OK_SEVERITY_COLOR,


### PR DESCRIPTION
should be backwards compatible in case anyone already is using these settings